### PR TITLE
Fix confusion about PvPTweaks depending on WorldEdit being present on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 ## Features
 **PvPTweaks** is a Minecraft plugin designed for servers running version b1.7.3.
 
-Implements additional tweaks to PvP that hook with WorldEdit and WorldGuard.
-
-The plugin is entirely configurable.
+Implements additional tweaks to PvP to further improve safety regulations.
 
 ---
 ## Contributing Code & Reporting Issues

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ If you'd like additional peace of mind, you're welcome to scan the `.jar` file u
 ## Requirements
 Your server must be running one of the following APIs: CB1060-CB1092, [Project Poseidon](https://github.com/retromcorg/Project-Poseidon) or [UberBukkit](https://github.com/Moresteck/Project-Poseidon-Uberbukkit).
 > [!CAUTION]
-> It also needs to be running both [**WorldEdit**](https://github.com/AleksandarHaralanov/PvPTweaks/raw/refs/heads/master/libs/WorldEdit.jar) and [**WorldGuard**](https://github.com/AleksandarHaralanov/PvPTweaks/raw/refs/heads/master/libs/WorldGuard.jar) for the plugin to function.
-> 
-> Click on the names to download each.
+> It also needs to be running [**WorldGuard**](https://github.com/AleksandarHaralanov/PvPTweaks/raw/refs/heads/master/libs/WorldGuard.jar) for the plugin to function.
 
 ---
 ## Configurations

--- a/src/main/java/io/github/aleksandarharalanov/pvptweaks/listener/EntityDamageListener.java
+++ b/src/main/java/io/github/aleksandarharalanov/pvptweaks/listener/EntityDamageListener.java
@@ -1,7 +1,6 @@
 package io.github.aleksandarharalanov.pvptweaks.listener;
 
 import com.sk89q.worldedit.Vector;
-import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldguard.bukkit.BukkitUtil;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
@@ -34,12 +33,6 @@ public class EntityDamageListener extends EntityListener {
         WorldGuardPlugin worldGuard = (WorldGuardPlugin) getServer().getPluginManager().getPlugin("WorldGuard");
         if (worldGuard == null || !worldGuard.isEnabled()) {
             logWarning("[PvPTweaks] PvP bow fix requires WorldGuard, but it is missing or disabled.");
-            return;
-        }
-
-        WorldEditPlugin worldEdit = (WorldEditPlugin) getServer().getPluginManager().getPlugin("WorldEdit");
-        if (worldEdit != null && worldEdit.isEnabled()) {
-            logWarning("[PvPTweaks] PvP bow fix requires WorldEdit, but it is missing or disabled.");
             return;
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 main: io.github.aleksandarharalanov.pvptweaks.PvPTweaks
-version: 1.0.0
+version: 1.0.1
 name: PvPTweaks
 author: Beezle
 website: github.com/AleksandarHaralanov/PvPTweaks
 description: Implements additional tweaks to PvP.
-depend: [WorldEdit, WorldGuard]
+depend: [WorldGuard]


### PR DESCRIPTION
It shouldn't depend, it only needs WorldGuard present.